### PR TITLE
ubuntu16 - systemd - babysit exit code 3

### DIFF
--- a/bin/aws-kinesis-agent-babysit
+++ b/bin/aws-kinesis-agent-babysit
@@ -15,7 +15,7 @@ function start_agent() {
 $SERVICE status >/dev/null 2>&1
 status=$?
 
-if [ "$status" -eq "1" -o "$status" -eq "2" ]; then
+if [ "$status" -eq "1" -o "$status" -eq "2" -o "$status" -eq "3" ]; then
   start_agent
 fi
 


### PR DESCRIPTION
`inactive (dead)` exit codes at 3:

```
[root@dev-ecs-uswest2-i-08dcdce8e:~]# service aws-kinesis-agent status
● aws-kinesis-agent.service - LSB: Daemon for Amazon Kinesis Agent.
   Loaded: loaded (/etc/init.d/aws-kinesis-agent; bad; vendor preset: enabled)
  Drop-In: /etc/systemd/system/aws-kinesis-agent.service.d
           └─remain.conf
   Active: inactive (dead) since Tue 2018-06-05 20:58:21 UTC; 5s ago
     Docs: man:systemd-sysv-generator(8)
  Process: 14170 ExecStop=/etc/init.d/aws-kinesis-agent stop (code=exited, status=0/SUCCESS)
  Process: 13917 ExecStart=/etc/init.d/aws-kinesis-agent start (code=exited, status=0/SUCCESS)

Jun 05 20:57:53 dev-ecs-uswest2-i-08dcdce8e systemd[1]: Starting LSB: Daemon for Amazon Kinesis Agent....
Jun 05 20:57:53 dev-ecs-uswest2-i-08dcdce8e aws-kinesis-agent[13917]:  * Starting aws-kinesis-agent
Jun 05 20:57:53 dev-ecs-uswest2-i-08dcdce8e aws-kinesis-agent[13917]:    ...done.
Jun 05 20:57:53 dev-ecs-uswest2-i-08dcdce8e systemd[1]: Started LSB: Daemon for Amazon Kinesis Agent..
Jun 05 20:58:21 dev-ecs-uswest2-i-08dcdce8e aws-kinesis-agent[14170]:  * Stopping aws-kinesis-agent
Jun 05 20:58:21 dev-ecs-uswest2-i-08dcdce8e aws-kinesis-agent[14170]: start-stop-daemon: warning: failed to kill 13927: No such process
Jun 05 20:58:21 dev-ecs-uswest2-i-08dcdce8e aws-kinesis-agent[14170]:    ...done.
[root@dev-ecs-uswest2-i-08dcdce8e:~:3]# echo $?
3
```